### PR TITLE
Add vagrant support so that developers can work locally [T#1]

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,117 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "ubuntu/xenial64"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  config.vm.provider "virtualbox" do |vb|
+    # Display the VirtualBox GUI when booting the machine
+    # vb.gui = true
+
+    # Customize the amount of memory on the VM:
+    vb.memory = "512"
+    vb.cpus = 1
+  end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Copy your .gitconfig file so that your git credentials are correct
+  if File.exists?(File.expand_path("~/.gitconfig"))
+    config.vm.provision "file", source: "~/.gitconfig", destination: "~/.gitconfig"
+  end
+
+  # Copy your ssh keys file so that your git credentials are correct
+  if File.exists?(File.expand_path("~/.ssh/id_rsa"))
+    config.vm.provision "file", source: "~/.ssh/id_rsa", destination: "~/.ssh/id_rsa"
+  end
+
+  ######################################################################
+  # Add Python Flask environment
+  ######################################################################
+  # Setup a Python development environment
+  config.vm.provision "shell", inline: <<-SHELL
+    apt-get update
+    apt-get install -y git python-pip python-dev build-essential
+    pip install --upgrade pip
+    apt-get -y autoremove
+    # Make vi look nice ;-)
+    sudo -H -u ubuntu echo "colorscheme desert" > ~/.vimrc
+    # Install app dependencies
+    cd /vagrant
+    sudo pip install -r requirements.txt
+  SHELL
+
+  ######################################################################
+  # Add Redis docker container
+  ######################################################################
+  config.vm.provision "shell", inline: <<-SHELL
+    # Prepare Redis data share
+    sudo mkdir -p /var/lib/redis/data
+    sudo chown ubuntu:ubuntu /var/lib/redis/data
+  SHELL
+
+  # Add Redis docker container
+  config.vm.provision "docker" do |d|
+    d.pull_images "redis:alpine"
+    d.run "redis",
+      image: "redis:alpine",
+      args: "-h redis -p 6379:6379 -v /var/lib/redis/data:/data",
+      restart: "always",
+      daemonize: true
+  end
+
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  config.vm.provision "shell", inline: <<-SHELL
+    apt-get update
+    apt-get install -y apache2
+  SHELL
+end


### PR DESCRIPTION
Add a vagrantfile to let each developer can have complete and same
development environment on each workstation. This vagranfile so far has
the feature as follows:

1. Customize the amount of memory on the VM
2. Copy your .gitconfig file
3. Copy your ssh keys file
4. Add Python Flask environment
5. Add Redis docker container
6. Enable provisioning with a shell script