### PR TITLE
Define ElephantSQL as a User Provided Services in Cloud Foundry [T#82]

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,19 +1,19 @@
 ---
 # This manifest deploys a Python Flask application with a Redis database
 applications:
-- name: nyu-product-service-f19
-  path: .
-  instances: 1
-  memory: 64M
-  #random-route: true
-  routes:
-  - route: nyu-product-service-f19.mybluemix.net
-  disk_quota: 1024M
-  buildpack: python_buildpack
-  timeout: 180
-  command: null
-  # services:
-  # - PostgreSQL
-  env:
-    FLASK_APP : service:app
-    FLASK_DEBUG : false
+  - name: nyu-product-service-f19
+    path: .
+    instances: 1
+    memory: 64M
+    #random-route: true
+    routes:
+      - route: nyu-product-service-f19.mybluemix.net
+    disk_quota: 1024M
+    buildpack: python_buildpack
+    timeout: 180
+    command: null
+    services:
+      - ElephantSQL
+    env:
+      FLASK_APP: service:app
+      FLASK_DEBUG: false

--- a/service/__init__.py
+++ b/service/__init__.py
@@ -18,10 +18,16 @@ and SQL database
 import os
 import sys
 from flask import Flask
+import json
 
 # Get configuration from environment
 DATABASE_URI = os.getenv('DATABASE_URI', 'postgres://postgres:postgres@localhost:5432/postgres')
 SECRET_KEY = os.getenv('SECRET_KEY', 's3cr3t-key-shhhh')
+
+if 'VCAP_SERVICES' in os.environ:
+    print('Getting database from VCAP_SERVICES')
+    vcap_services = json.loads(os.environ['VCAP_SERVICES'])
+    DATABASE_URI = vcap_services['user-provided'][0]['credentials']['database_uri']
 
 # Create Flask application
 app = Flask(__name__)


### PR DESCRIPTION
Define ElephantSQL as a User Provided Services in Cloud Foundry and use the VCAP_SERVICES environment variable instead.